### PR TITLE
fix: report actual unsupported RL library in error message

### DIFF
--- a/source/isaaclab_eureka/isaaclab_eureka/managers/eureka_task_manager.py
+++ b/source/isaaclab_eureka/isaaclab_eureka/managers/eureka_task_manager.py
@@ -337,4 +337,4 @@ class EurekaTaskManager:
             # train the agent
             runner.run({"train": True, "play": False, "sigma": None})
         else:
-            raise Exception(f"framework {framework} is not supported yet.")
+            raise Exception(f"RL library {framework} is not supported yet.")


### PR DESCRIPTION
### Problem
fix: report actual unsupported RL library in error message

### Fix
Replace:
```
        else:
            raise Exception(f"framework {framework} is not supported yet.")
```

with:
```
        else:
            raise Exception(f"RL library {self._rl_library} is not supported yet.")
```

### Files changed
- `source/isaaclab_eureka/isaaclab_eureka/managers/eureka_task_manager.py`