### PR TITLE
fix: require checkpoint argument for inference script

### DIFF
--- a/scripts/play.py
+++ b/scripts/play.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
     parser.add_argument("--task", type=str, default="Isaac-Cartpole-Direct-v0", help="Name of the task.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
     parser.add_argument("--device", type=str, default="cuda", help="The device to run training on.")
-    parser.add_argument("--checkpoint", type=str, default=None, help="Absolute path to model checkpoint.")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Absolute path to model checkpoint.")
     parser.add_argument(
         "--rl_library",
         type=str,


### PR DESCRIPTION
### Problem
fix: require checkpoint argument for inference script

### Fix
Replace:
```
    parser.add_argument("--checkpoint", type=str, default=None, help="Absolute path to model checkpoint.")
```

with:
```
    parser.add_argument("--checkpoint", type=str, required=True, help="Absolute path to model checkpoint.")
```

### Files changed
- `scripts/play.py`